### PR TITLE
fix pycall CI error

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.9.0'
           - 'nightly'
         os:
           - ubuntu-latest

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,17 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      #- uses: julia-actions/cache@v1
+      - name: Cache 📖
+        uses: actions/cache@v2
+        with:
+          path: |
+                ${{ env.SITE_FOLDER }}/__cache
+                ${{ env.SITE_FOLDER }}/__site
+                ~/.julia/artifacts
+                ~/.julia/packages
+                !~/.julia/packages/PyCall
+                !~/.julia/packages/Conda
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -43,6 +43,7 @@ jobs:
                 ~/.julia/packages
                 !~/.julia/packages/PyCall
                 !~/.julia/packages/Conda
+          key: ${{ runner.os }}-julia-${{ hashFiles('**/Project.toml') }}
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -32,7 +32,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      #- uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -18,7 +18,7 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9.0'
+          - '1.9'
           - 'nightly'
         os:
           - ubuntu-latest
@@ -32,7 +32,7 @@ jobs:
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      #- uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v1
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
       - uses: julia-actions/julia-processcoverage@v1

--- a/Project.toml
+++ b/Project.toml
@@ -6,6 +6,7 @@ version = "0.1.0"
 [deps]
 BenchmarkTools = "6e4b80f9-dd63-53aa-95a3-0cdb28fa8baf"
 CSV = "336ed68f-0bac-5ca0-87d4-7b16caf5d00b"
+Conda = "8f4d0f93-b110-5947-807f-2305c1781a2d"
 DataFrames = "a93c6f00-e57d-5684-b7b6-d8193f3e46c0"
 DataFramesMeta = "1313f7d8-7da2-5740-9ea0-a2ca25f37964"
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"

--- a/docs/Manifest.toml
+++ b/docs/Manifest.toml
@@ -395,7 +395,7 @@ uuid = "c8ffd9c3-330d-5841-b78e-0817d7145fa1"
 version = "2.28.2+0"
 
 [[deps.MicroTracker]]
-deps = ["BenchmarkTools", "CSV", "DataFrames", "DataFramesMeta", "Dates", "FFTW", "Optim", "PyCall", "Reexport", "Statistics"]
+deps = ["BenchmarkTools", "CSV", "Conda", "DataFrames", "DataFramesMeta", "Dates", "FFTW", "Optim", "PyCall", "Reexport", "Statistics"]
 path = ".."
 uuid = "f2f4b30c-0e7b-4018-b992-2f46df5706a6"
 version = "0.1.0"

--- a/src/MicroTracker.jl
+++ b/src/MicroTracker.jl
@@ -5,7 +5,7 @@ module MicroTracker
 # See PyCall docs on how this was set up
 # https://github.com/JuliaPy/PyCall.jl#quick-start
 
-using PyCall  # maybe import conda first?
+using Conda, PyCall 
 
 const np = PyNULL()
 const tp = PyNULL()

--- a/src/MicroTracker.jl
+++ b/src/MicroTracker.jl
@@ -5,7 +5,7 @@ module MicroTracker
 # See PyCall docs on how this was set up
 # https://github.com/JuliaPy/PyCall.jl#quick-start
 
-using PyCall
+using PyCall  # maybe import conda first?
 
 const np = PyNULL()
 const tp = PyNULL()


### PR DESCRIPTION
When running CI, building PyCall fails with this error.  

```
Building PyCall → `~/.julia/scratchspaces/44cfe95a-1eb2-52ea-b672-e2afdf69b78f/08c74e61c63bf63530c03cde3fe59586fcae8941/build.log`
ERROR: LoadError: Error building `PyCall`: 
ERROR: LoadError: ArgumentError: Path to conda environment is not valid: /home/runner/.julia/conda/3/x86_64
```